### PR TITLE
Close tf::Executor prior library close

### DIFF
--- a/sources/SplaLibrary.cpp
+++ b/sources/SplaLibrary.cpp
@@ -118,6 +118,7 @@ std::vector<std::string> spla::Library::Config::GetDevicesNames() const {
         if (mPlatformName.has_value() && platform.name() != mPlatformName.value()) {
             continue;
         }
+        platformExists = true;
         for (const boost::compute::device &device : platform.devices()) {
             bool matchType = !mDeviceType.has_value() || ((mDeviceType.value() == GPU && device.type() == boost::compute::device::type::gpu) ||
                                                           (mDeviceType.value() == CPU && device.type() == boost::compute::device::type::cpu) ||

--- a/sources/core/SplaLibraryPrivate.cpp
+++ b/sources/core/SplaLibraryPrivate.cpp
@@ -90,10 +90,15 @@ spla::LibraryPrivate::LibraryPrivate(
     mDefaultDesc = Descriptor::Make(library);
     mExprManager = RefPtr<ExpressionManager>(new ExpressionManager(library));
     mAlgoManager = RefPtr<AlgorithmManager>(new AlgorithmManager(library));
+    mExecutor = std::make_shared<tf::Executor>();
+}
+
+spla::LibraryPrivate::~LibraryPrivate() {
+    mExecutor.reset();
 }
 
 tf::Executor &spla::LibraryPrivate::GetTaskFlowExecutor() noexcept {
-    return mExecutor;
+    return *mExecutor;
 }
 
 const spla::RefPtr<spla::Descriptor> &spla::LibraryPrivate::GetDefaultDesc() const noexcept {

--- a/sources/core/SplaLibraryPrivate.hpp
+++ b/sources/core/SplaLibraryPrivate.hpp
@@ -57,6 +57,7 @@ namespace spla {
     class LibraryPrivate {
     public:
         explicit LibraryPrivate(Library &library, Library::Config config);
+        ~LibraryPrivate();
 
         tf::Executor &GetTaskFlowExecutor() noexcept;
 
@@ -84,7 +85,7 @@ namespace spla {
         std::size_t GetBlockSize() const noexcept;
 
     private:
-        tf::Executor mExecutor;
+        std::shared_ptr<tf::Executor> mExecutor;
         RefPtr<Descriptor> mDefaultDesc;
         RefPtr<ExpressionManager> mExprManager;
         RefPtr<AlgorithmManager> mAlgoManager;


### PR DESCRIPTION
Since executor joins job threads, and destroys thread
local cl program caches (in boost.comput), open cl
context must stay valid until this process